### PR TITLE
Corrected nginx start warnings by starting nginx with root and worker process as nobody

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ COPY index.html /usr/share/nginx/html/index.html
 EXPOSE 8080
 VOLUME ["/usr/share/nginx/html"]
 
-# Start nginx without root
-USER nobody
-
+# root user will run 'nginx: master process'
+# nobody user will run 'nginx: worker process' as dictated in the nginx.non-root.conf
 CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Sample with Alpine Linux as base image. Small container, about 6.7 MB size.
 
-The image will run as `nobody` user instead of `root`.
+The image will run the nginx master process as `root` and the worker process as `nobody` user instead of `root`.
 
 ## Build image
 
@@ -22,10 +22,6 @@ Removing intermediate container 8cf9ebc817c0
 Step 3 : COPY index.html /usr/share/nginx/html/index.html
  ---> 66ef2d118a55
 Removing intermediate container fcdf5cf7659d
-Step 4 : USER nobody
- ---> Running in f29ac1ee7d2b
- ---> af2a00e1517f
-Removing intermediate container f29ac1ee7d2b
 Step 5 : CMD nginx -g daemon off;
  ---> Running in 924416d06df6
  ---> 792212e8fbc1
@@ -37,9 +33,9 @@ Successfully built 792212e8fbc1
 
 To start image you could use `docker run -td -p 80:8080 minimal-nginx`. Or if using dockerhub: `docker run -td -p 80:8080 sdelrio/docker-minimal-nginx`.
 
-We can see nginx process is now running with user nobody instead of root.
+We can see nginx process is now running the nginx master process as `root` and the worker process as the `nobody` user instead of `root`.
 
-To change the content of the html to show your current directory html add the parameter `-v $(pwd):/usr/share/nginx/html`.
+Map the volume to your current directory `-v $(pwd):/usr/share/nginx/html`.
 
 ```
 $ docker run -td -p 80:8080 minimal-nginx
@@ -51,9 +47,9 @@ CONTAINER ID        IMAGE                  COMMAND                  CREATED     
 
 $ docker exec evil_yalow ps
 PID   USER     TIME   COMMAND
-    1 nobody     0:00 nginx: master process nginx -g daemon off;
-    7 nobody     0:00 nginx: worker process
-    8 nobody     0:00 ps
+    1 root       0:00 nginx: master process nginx -g daemon off;
+    5 nobody     0:00 nginx: worker process
+    7 nobody     0:00 ps
 ```
 
 ## References

--- a/nginx.non-root.conf
+++ b/nginx.non-root.conf
@@ -1,4 +1,5 @@
 worker_processes 1;
+user nobody nobody;
 error_log /tmp/error.log;
 pid /tmp/nginx.pid;
 


### PR DESCRIPTION
Hi, 

I hope you accept these changes as they allow the image to run warning free and nginx now start following the standard method where the master process runs as root and the worker process' run as nobody. Maybe they should be the www-data user(which exists in alpine) but it really doesn't matter.
