### PR TITLE
NO-REF: typo fix

### DIFF
--- a/nginx.non-root.conf
+++ b/nginx.non-root.conf
@@ -29,7 +29,7 @@ http {
 
         root /usr/share/nginx/html;
         access_log /dev/stdout;
-        error_log /dev/stdou;
+        error_log /dev/stdout;
     }
 
 }


### PR DESCRIPTION
Error log should be redirected to `/dev/stdout`, not `/dev/stdou`
btw, thanks a lot for your repo